### PR TITLE
add `nodePort: null` to traefik service ports config

### DIFF
--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -205,10 +205,12 @@ traefik:
       web:
         # The port HTTP(s) requests will be served on
         port: 80
+        nodePort: null
       tcp:
         # The port TCP requests will be served on. Set to `web` to share the
         # web service port
         port: web
+        nodePort: null
 
   # Settings for nodeSelector, affinity, and tolerations for the traefik pods
   nodeSelector: {}


### PR DESCRIPTION
Addresses deployment with service type `ClusterIP` -- https://github.com/dask/dask-gateway/issues/304